### PR TITLE
`set-output` command is deprecated

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       id: check-release-tag
       run: |
         if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$ ]]; then
-          echo ::set-output name=release_tag::true
+          echo "release_tag=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Publish to PyPI


### PR DESCRIPTION
`set-output` command is deprecated and will be disabled on 31st May 2023.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/